### PR TITLE
Update documentation about removing end reason from the public

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,4 +103,4 @@ Special Thanks
 - [jquery.tocify.js](https://github.com/gfranko/jquery.tocify.js)
 - [middleman-syntax](https://github.com/middleman/middleman-syntax)
 - [middleman-gh-pages](https://github.com/edgecase/middleman-gh-pages)
-- [Font Awesome](http://fortawesome.github.io/Font-Awesome/)
+- [Font Awesome](http://fortawesome.github.io/Font-Awesome/) 


### PR DESCRIPTION
Update documentation about removing end reason from the public
facing sytem parts

Related:
https://github.com/salemove/acceptance_tests/pull/899
https://github.com/salemove/engagement-archiver/pull/46
https://github.com/salemove/mailer/pull/23
https://github.com/salemove/crm-exporter/pull/71

EX-79
